### PR TITLE
(bug fix for issue #47): favourites not returning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jira-plugin",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/shared/select-utilities.ts
+++ b/src/shared/select-utilities.ts
@@ -325,8 +325,15 @@ export const selectFavoriteFilters = async (): Promise<IFavouriteFilter | undefi
             favFilters
               .filter(filter => {
                 let valid = true;
-                otherProjects.forEach(prj => {
-                  if (filter.jql.indexOf(prj.key) >= 0 || filter.jql.indexOf(prj.name) >= 0) {
+                otherProjects.forEach(prj => 
+                {
+                  let regexp0 = new RegExp('project = "?' + prj.key + '"?');
+                  let regexp1 = new RegExp('project in \(.*?"?' + prj.key + '"?.*?\)');
+                  let regexp2 = new RegExp('"Project Name" in \(.*?"?' + prj.name + '"?.*?\)');
+                  let regexp3 = new RegExp('"Project Name" = "?' + prj.name + '"?');
+                  
+                  if ( regexp0.test(filter.jql) || regexp1.test(filter.jql) || regexp2.test(filter.jql) || regexp3.test(filter.jql) ) 
+                  {
                     valid = false;
                   }
                 });


### PR DESCRIPTION
In the event of a project ID or project name existing anywhere in the JQL of the JIRA filter it will not be returned to VS Code. 

Example: Project name: DER

JQL string contains: "ORDER BY field a"

The favourite would not be returned in this example. Fix has been applied to utilise a regular expression for the various predicates that are possible in JIRA for project key and project name which include variants for project = and project IN etc..... 