### PR TITLE
fix: add modal in the git integration workflow

### DIFF
--- a/src/commands/set-working-issue.ts
+++ b/src/commands/set-working-issue.ts
@@ -7,7 +7,7 @@ import { selectChangeWorkingIssue, selectWorkingIssues } from '../shared/select-
 import { secondsToHHMMSS, secondsToMinutes } from '../shared/utilities';
 import state, { changeStateWorkingIssue } from '../state/state';
 
-export default async function setWorkingIssueCommand(storedWorkingIssue: IWorkingIssue): Promise<void> {
+export default async function setWorkingIssueCommand(storedWorkingIssue: IWorkingIssue, preloadedIssue: IIssue): Promise<void> {
   // run it's called from status bar there is a working issue in the storage
   if (!!storedWorkingIssue) {
     const workingIssues = await selectWorkingIssues();
@@ -28,7 +28,7 @@ export default async function setWorkingIssueCommand(storedWorkingIssue: IWorkin
   } else {
     // normal workflow, user must select a working issue
     const workingIssue = state.workingIssue || new NoWorkingIssuePick().pickValue;
-    const newIssue = await selectChangeWorkingIssue();
+    const newIssue = preloadedIssue || (await selectChangeWorkingIssue());
     if (!!newIssue && newIssue.key !== workingIssue.issue.key) {
       if (
         workingIssue.issue.key !== NO_WORKING_ISSUE.key &&

--- a/src/shared/status-bar.ts
+++ b/src/shared/status-bar.ts
@@ -56,7 +56,7 @@ export class StatusBarManager {
       issue = getGlobalWorkingIssue(state.context);
       if (!!issue) {
         // if there is a stored working issue we will use it
-        vscode.commands.executeCommand('jira-plugin.setWorkingIssueCommand', JSON.parse(issue));
+        vscode.commands.executeCommand('jira-plugin.setWorkingIssueCommand', JSON.parse(issue), undefined);
         setGlobalWorkingIssue(state.context, undefined);
         return;
       }

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -87,13 +87,15 @@ export const verifyCurrentProject = (project: string | undefined): boolean => {
 };
 
 export const changeStateProject = (project: string): void => {
-  setConfigurationByKey(CONFIG.WORKING_PROJECT, project);
-  // update project item in the status bar
-  state.statusBar.updateWorkingProjectItem(project);
-  // loading in Jira explorer
-  changeStateIssues(LOADING.text, '', []);
-  // launch search for the new project
-  setTimeout(() => vscode.commands.executeCommand('jira-plugin.allIssuesCommand'), 1000);
+  if (getConfigurationByKey(CONFIG.WORKING_PROJECT) !== project) {
+    setConfigurationByKey(CONFIG.WORKING_PROJECT, project);
+    // update project item in the status bar
+    state.statusBar.updateWorkingProjectItem(project);
+    // loading in Jira explorer
+    changeStateIssues(LOADING.text, '', []);
+    // launch search for the new project
+    setTimeout(() => vscode.commands.executeCommand('jira-plugin.allIssuesCommand'), 1000);
+  }
 };
 
 export const changeStateIssues = (filter: string, jql: string, issues: IIssue[]): void => {


### PR DESCRIPTION
When git branch name is <issue_key> `e.g. ABC-123` the plugin ask with a modal alert if change current working project and issue.