### PR TITLE
Refactoring/configuration service updates

### DIFF
--- a/src/commands/set-working-issue.ts
+++ b/src/commands/set-working-issue.ts
@@ -30,8 +30,7 @@ export default async function setWorkingIssueCommand(storedWorkingIssue: IWorkin
     if (!!newIssue && newIssue.key !== workingIssue.issue.key) {
       if (
         workingIssue.issue.key !== NO_WORKING_ISSUE.key &&
-        utilities.floorSecondsToMinutes(workingIssue.trackingTime) >=
-          parseInt(configuration.get(CONFIG.WORKLOG_MINIMUM_TRACKING_TIME, '0'), 10)
+        utilities.floorSecondsToMinutes(workingIssue.trackingTime) >= configuration.get(CONFIG.WORKLOG_MINIMUM_TRACKING_TIME)
       ) {
         // old working issue has trackingTime and it's equal or bigger then WORKLOG_MINIMUM_TRACKING_TIME setting
         statusBar.clearWorkingIssueInterval();

--- a/src/commands/setup-credentials.ts
+++ b/src/commands/setup-credentials.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
+import { configuration } from '../services';
 import { CONFIG } from '../shared/constants';
 import { connectToJira } from '../store/state';
-import { configuration } from '../services';
 
 export default async function setupCredentials(): Promise<void> {
   const baseUrl = configuration.get(CONFIG.BASE_URL);
@@ -33,7 +33,7 @@ export default async function setupCredentials(): Promise<void> {
     })
   );
 
-  configuration.setGlobalState(
+  configuration.setPassword(
     await vscode.window.showInputBox({
       ignoreFocusOut: true,
       password: true,

--- a/src/explorer/jira-explorer.ts
+++ b/src/explorer/jira-explorer.ts
@@ -54,7 +54,7 @@ export default class JiraExplorer implements vscode.TreeDataProvider<IssueItem> 
         }
       });
 
-      if (issues.length === parseInt(configuration.get(CONFIG.NUMBER_ISSUES_IN_LIST, '50'), 10)) {
+      if (issues.length === configuration.get(CONFIG.NUMBER_ISSUES_IN_LIST)) {
         items.push(new DividerItem('------'), new LimitInfoItem());
       }
       return items;

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -1,58 +1,85 @@
 import { configuration, logger } from '../services';
-import { ASSIGNEES_MAX_RESULTS, CONFIG, CREDENTIALS_SEPARATOR } from '../shared/constants';
-import { IAddComment, IAddCommentResponse, IAddWorkLog, IAssignee, IAvailableLinkIssuesType, ICreateIssue, ICreateIssueEpic, ICreateMetadata, IFavouriteFilter, IIssue, IIssueType, IJira, ILabel, IPriority, IProject, ISearch, ISetTransition, IStatus, ITransitions } from './api.model';
+import { ASSIGNEES_MAX_RESULTS, CONFIG } from '../shared/constants';
+import {
+  IAddComment,
+  IAddCommentResponse,
+  IAddWorkLog,
+  IAssignee,
+  IAvailableLinkIssuesType,
+  ICreateIssue,
+  ICreateIssueEpic,
+  ICreateMetadata,
+  IFavouriteFilter,
+  IIssue,
+  IIssueType,
+  IJira,
+  ILabel,
+  IPriority,
+  IProject,
+  ISearch,
+  ISetTransition,
+  IStatus,
+  ITransitions
+} from './api.model';
 
 const jiraClient = require('jira-connector');
 
 export class Jira implements IJira {
   jiraInstance: any;
-  baseUrl: string;
+  baseUrl: string | undefined;
 
   constructor() {
+    if (!configuration.isValid()) {
+      logger.printErrorMessageInOutputAndShowAlert('Error: Check Jira Plugin settings in VSCode.');
+      return;
+    }
+
     this.baseUrl = configuration.get(CONFIG.BASE_URL);
 
-    if (this.baseUrl && configuration.globalState) {
-      // prepare config for jira-connector
-      let host = this.baseUrl;
-      const protocol = host.indexOf('https://') >= 0 ? 'https' : 'http';
-      host = host.replace('https://', '').replace('http://', '');
-      const portPosition = host.indexOf(':');
-      const port = portPosition !== -1 ? host.substring(portPosition + 1) : undefined;
-      if (portPosition !== -1) {
-        host = host.substring(0, portPosition);
-      }
-      const [username, password] = configuration.globalState.split(CREDENTIALS_SEPARATOR);
-      this.jiraInstance = new jiraClient({ host, port, protocol, basic_auth: { username, password } });
+    // prepare config for jira-connector
+    let host = this.baseUrl;
+    const protocol = host.indexOf('https://') >= 0 ? 'https' : 'http';
+    host = host.replace('https://', '').replace('http://', '');
+    const portPosition = host.indexOf(':');
+    const port = portPosition !== -1 ? host.substring(portPosition + 1) : undefined;
 
-      // custom event
-      // solve this issue -> https://github.com/floralvikings/jira-connector/issues/115
-      const customGetAllProjects = (opts: any, callback: any) => {
-        const options = this.jiraInstance.project.buildRequestOptions(opts, '', 'GET');
-        if (Object.keys(options.body).length === 0) {
-          delete options.body;
-        }
-        if (Object.keys(options.qs).length === 0) {
-          delete options.qs;
-        }
-        return this.jiraInstance.makeRequest(options, callback);
-      };
-      this.jiraInstance.project.getAllProjects = customGetAllProjects;
-
-      const customApiCall = (uri: string, callback: any) => {
-        const options = this.jiraInstance.project.buildRequestOptions({}, '', 'GET');
-        if (Object.keys(options.body).length === 0) {
-          delete options.body;
-        }
-        if (Object.keys(options.qs).length === 0) {
-          delete options.qs;
-        }
-        options.uri = uri;
-        return this.jiraInstance.makeRequest(options, callback);
-      };
-      this.jiraInstance.project.customApiCall = customApiCall;
-    } else {
-      logger.printErrorMessageInOutputAndShowAlert('Error: Check Jira Plugin settings in VSCode.');
+    if (portPosition !== -1) {
+      host = host.substring(0, portPosition);
     }
+
+    this.jiraInstance = new jiraClient({
+      host,
+      port,
+      protocol,
+      basic_auth: configuration.credentials
+    });
+
+    // custom event
+    // solve this issue -> https://github.com/floralvikings/jira-connector/issues/115
+    const customGetAllProjects = (opts: any, callback: any) => {
+      const options = this.jiraInstance.project.buildRequestOptions(opts, '', 'GET');
+      if (Object.keys(options.body).length === 0) {
+        delete options.body;
+      }
+      if (Object.keys(options.qs).length === 0) {
+        delete options.qs;
+      }
+      return this.jiraInstance.makeRequest(options, callback);
+    };
+    this.jiraInstance.project.getAllProjects = customGetAllProjects;
+
+    const customApiCall = (uri: string, callback: any) => {
+      const options = this.jiraInstance.project.buildRequestOptions({}, '', 'GET');
+      if (Object.keys(options.body).length === 0) {
+        delete options.body;
+      }
+      if (Object.keys(options.qs).length === 0) {
+        delete options.qs;
+      }
+      options.uri = uri;
+      return this.jiraInstance.makeRequest(options, callback);
+    };
+    this.jiraInstance.project.customApiCall = customApiCall;
   }
 
   async search(params: { jql: string; maxResults: number }): Promise<ISearch> {

--- a/src/http/api.ts
+++ b/src/http/api.ts
@@ -26,10 +26,11 @@ const jiraClient = require('jira-connector');
 
 export class Jira implements IJira {
   jiraInstance: any;
-  baseUrl: string | undefined;
+  baseUrl: string;
 
   constructor() {
     if (!configuration.isValid()) {
+      this.baseUrl = '';
       logger.printErrorMessageInOutputAndShowAlert('Error: Check Jira Plugin settings in VSCode.');
       return;
     }

--- a/src/services/configuration.service.ts
+++ b/src/services/configuration.service.ts
@@ -42,22 +42,22 @@ export default class ConfigurationService {
   }
 
   // used for get only one setting
-  public get(entry: string, fallbackValue?: string): string {
-    const config = this.settings;
-    let result = config && (<any>config).get(entry);
-    return (result || fallbackValue || '').toString();
+  public get(entry: string, fallbackValue?: any): any {
+    if (!this.settings) {
+      return fallbackValue;
+    }
+
+    return this.settings.get(entry, fallbackValue);
   }
 
   // used for set only one setting
-  public async set(entry: string, value: string | undefined): Promise<any> {
-    const config = this.settings;
-
+  public async set(entry: string, value: any): Promise<any> {
     // remove / at the end if exist
-    if (value && entry === CONFIG.BASE_URL) {
+    if (entry === CONFIG.BASE_URL && typeof value === 'string') {
       value = value.replace(/\/$/, '');
     }
 
-    return config && config.update(entry, value || '', true);
+    return this.settings && this.settings.update(entry, value, true);
   }
 
   // set inside VS Code local storage the settings

--- a/src/services/configuration.service.ts
+++ b/src/services/configuration.service.ts
@@ -45,21 +45,18 @@ export default class ConfigurationService {
   public get(entry: string, fallbackValue?: string): string {
     const config = this.settings;
     let result = config && (<any>config).get(entry);
-    // remove / at the end if exist
-    switch (entry) {
-      case CONFIG.BASE_URL: {
-        if (result && result.substring(result.length - 1) === '/') {
-          result = result.substring(0, result.length - 1);
-        }
-        break;
-      }
-    }
     return (result || fallbackValue || '').toString();
   }
 
   // used for set only one setting
   public async set(entry: string, value: string | undefined): Promise<any> {
     const config = this.settings;
+
+    // remove / at the end if exist
+    if (value && entry === CONFIG.BASE_URL) {
+      value = value.replace(/\/$/, '');
+    }
+
     return config && config.update(entry, value || '', true);
   }
 

--- a/src/services/select-values.service.ts
+++ b/src/services/select-values.service.ts
@@ -136,7 +136,7 @@ export default class SelectValuesService {
           if (!!jql) {
             logger.jiraPluginDebugLog(`${filter} jql`, jql);
             // call Jira API with the generated JQL
-            const maxResults = Math.min(parseInt(configuration.get(CONFIG.NUMBER_ISSUES_IN_LIST, '50'), 10), SEARCH_MAX_RESULTS);
+            const maxResults = Math.min(configuration.get(CONFIG.NUMBER_ISSUES_IN_LIST), SEARCH_MAX_RESULTS);
             const searchResult = await state.jira.search({
               jql,
               maxResults

--- a/src/services/status-bar.service.ts
+++ b/src/services/status-bar.service.ts
@@ -13,7 +13,7 @@ export default class StatusBarService {
   constructor(configuration: ConfigurationService) {
     this.workingIssueItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
     this.workingProjectItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 200);
-    this.awayTimeout = parseInt(configuration.get(CONFIG.TRACKING_TIME_MODE_HYBRID_TIMEOUT, '30'), 10) * 60;
+    this.awayTimeout = configuration.get(CONFIG.TRACKING_TIME_MODE_HYBRID_TIMEOUT) * 60;
   }
 
   // setup working project item

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -123,7 +123,7 @@ export const addAdditionalStatuses = () => {
     const additionalStatuses = configuration.get(CONFIG.ADDITIONAL_STATUSES);
     if (!!additionalStatuses) {
       const list = additionalStatuses.split(',');
-      list.forEach(status => {
+      list.forEach((status: string) => {
         const newStatus = status.trim();
         if (!!newStatus && !state.statuses.find(el => el.name.toLowerCase() === newStatus.toLowerCase())) {
           state.statuses.push({

--- a/test/tests/configuration.test.ts
+++ b/test/tests/configuration.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import ConfigurationService from '../../src/services/configuration.service';
-import { CONFIG, CREDENTIALS_SEPARATOR, DEFAULT_WORKING_ISSUE_STATUS } from '../../src/shared/constants';
+import { CONFIG, DEFAULT_WORKING_ISSUE_STATUS } from '../../src/shared/constants';
 import state from '../../src/store/state';
 
 suite('Configuration', () => {
@@ -64,22 +64,22 @@ suite('Configuration', () => {
 
   test(`Password config`, async () => {
     const password = 'my_password';
-    await configuration.setGlobalState(password);
-    const result = configuration.globalState.split(CREDENTIALS_SEPARATOR)[1];
+    await configuration.setPassword(password);
+    const { password: result } = configuration.credentials;
     assert.equal(password, result);
   });
 
   test(`Valid config`, async () => {
     await configuration.set(CONFIG.BASE_URL, 'baseUrl');
     await configuration.set(CONFIG.USERNAME, 'my_username');
-    await configuration.setGlobalState('my_password');
+    await configuration.setPassword('my_password');
     assert.equal(configuration.isValid(), true);
   });
 
   test(`NOT valid config`, async () => {
     await configuration.set(CONFIG.BASE_URL, 'baseUrl');
     await configuration.set(CONFIG.USERNAME, undefined);
-    await configuration.setGlobalState('my_password');
+    await configuration.setPassword('my_password');
     assert.equal(configuration.isValid(), false);
   });
 


### PR DESCRIPTION
Small code improvements related to Configuration Service.

- Better credentials management. Removed copy-paste splitting string logic
- BASE_URL trailing slash is now handled on `set`
- Enabled native VS Code configuration feature.
  *  Variable type detection based on package.json 
  * Default values based on package.json

Further points to improvement regarding the configuration service.
- Use native [dotted](https://code.visualstudio.com/api/references/vscode-api#workspace.getConfiguration) variable key splitting 
This opens a tons of capabilities like scoped configuration which can be passed along to other objects
- Consider removing the need for globalState access, as well as setting target to global [here](https://github.com/gioboa/jira-plugin/blob/develop/src/services/configuration.service.ts#L50)
All projects are folder based or workspace based so let's be able to set different configuration for each, and this still doesn't prevent user to set global configuration
- Detect scenario when the code is ran under the test, to prevent messing up with "production" settings