### PR TITLE
fix: use displayName in picker if available such as in assignee field

### DIFF
--- a/src/services/issue-helper.service.ts
+++ b/src/services/issue-helper.service.ts
@@ -101,7 +101,7 @@ export default class IssueHelperService {
   }
 
   public getPickValue(value: any): string {
-    return value.inward || value.name || value.value || value.key || value.label || Object.values(value)[0]; // do not change order
+    return value.inward || value.displayName || value.name || value.value || value.key || value.label || Object.values(value)[0]; // do not change order
   }
 
   // define if the selector can have multiple choices


### PR DESCRIPTION
When selecting assignee during issue creation, the quick picker currently shows user ID URLs instead of the user's displayName. The intent of this section of code is to determine a user-friendly label for each choice, so I added `displayName` as a source taking priority over `name`.